### PR TITLE
Contribute to agent properties

### DIFF
--- a/lider-package-manager/src/main/java/tr/org/liderahenk/packagemanager/commands/CheckPackageCommand.java
+++ b/lider-package-manager/src/main/java/tr/org/liderahenk/packagemanager/commands/CheckPackageCommand.java
@@ -1,18 +1,39 @@
 package tr.org.liderahenk.packagemanager.commands;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tr.org.liderahenk.lider.core.api.persistence.dao.IAgentDao;
+import tr.org.liderahenk.lider.core.api.persistence.entities.IAgent;
+import tr.org.liderahenk.lider.core.api.persistence.entities.ICommandExecutionResult;
+import tr.org.liderahenk.lider.core.api.persistence.factories.IEntityFactory;
 import tr.org.liderahenk.lider.core.api.plugin.ICommand;
 import tr.org.liderahenk.lider.core.api.plugin.IPluginInfo;
+import tr.org.liderahenk.lider.core.api.plugin.ITaskAwareCommand;
 import tr.org.liderahenk.lider.core.api.service.ICommandContext;
 import tr.org.liderahenk.lider.core.api.service.ICommandResult;
 import tr.org.liderahenk.lider.core.api.service.ICommandResultFactory;
 import tr.org.liderahenk.lider.core.api.service.enums.CommandResultStatus;
 
-public class CheckPackageCommand implements ICommand {
+public class CheckPackageCommand implements ICommand, ITaskAwareCommand {
+
+	private static final Logger logger = LoggerFactory.getLogger(CheckPackageCommand.class);
+
+	// These strings are subject to change (check related strings in
+	// check_package.py):
+	private static final String NOT_INSTALLED = "Paket yüklü değil";
 
 	private ICommandResultFactory resultFactory;
 	private IPluginInfo pluginInfo;
+	private IAgentDao agentDao;
+	private IEntityFactory entityFactory;
 
 	@Override
 	public ICommandResult execute(ICommandContext context) {
@@ -21,7 +42,35 @@ public class CheckPackageCommand implements ICommand {
 
 	@Override
 	public ICommandResult validate(ICommandContext context) {
-		return resultFactory.create(CommandResultStatus.OK, null, this, null);
+		return resultFactory.create(CommandResultStatus.OK, null, this);
+	}
+
+	@Override
+	public void onTaskUpdate(ICommandExecutionResult result) {
+		try {
+			Map<String, Object> parameterMap = result.getCommandExecution().getCommand().getTask().getParameterMap();
+			Map<String, Object> responseData = new ObjectMapper().readValue(result.getResponseData(), 0,
+					result.getResponseData().length, new TypeReference<HashMap<String, Object>>() {
+					});
+			String packageName = parameterMap.get("packageName").toString();
+			String packageVersion = responseData.get("version").toString();
+			String chResult = responseData.get("res").toString();
+			if (!NOT_INSTALLED.equalsIgnoreCase(chResult)) {
+				logger.info("Package {}:{} found, adding package property to database.",
+						new Object[] { packageName, packageVersion });
+				Map<String, Object> data = new HashMap<String, Object>();
+				data.put(packageName, packageVersion);
+				// Update agent - add new property for the package found
+				List<? extends IAgent> agents = agentDao.findByProperty(IAgent.class, "jid",
+						result.getCommandExecution().getUid(), 1);
+				IAgent agent = agents != null && !agents.isEmpty() ? agents.get(0) : null;
+				agent = entityFactory.createAgent(agent, agent.getPassword(), agent.getHostname(),
+						agent.getIpAddresses(), agent.getMacAddresses(), data);
+				agentDao.update(agent);
+			}
+		} catch (Exception e) {
+			logger.error(e.getMessage(), e);
+		}
 	}
 
 	@Override
@@ -50,6 +99,14 @@ public class CheckPackageCommand implements ICommand {
 
 	public void setPluginInfo(IPluginInfo pluginInfo) {
 		this.pluginInfo = pluginInfo;
+	}
+
+	public void setAgentDao(IAgentDao agentDao) {
+		this.agentDao = agentDao;
+	}
+
+	public void setEntityFactory(IEntityFactory entityFactory) {
+		this.entityFactory = entityFactory;
 	}
 
 }

--- a/lider-package-manager/src/main/java/tr/org/liderahenk/packagemanager/commands/GetExecutionInfoCommand.java
+++ b/lider-package-manager/src/main/java/tr/org/liderahenk/packagemanager/commands/GetExecutionInfoCommand.java
@@ -34,6 +34,7 @@ import tr.org.liderahenk.packagemanager.entities.CommandExecutionStatistics;
 import tr.org.liderahenk.packagemanager.entities.CommandPackageVersion;
 
 public class GetExecutionInfoCommand implements ICommand, ITaskAwareCommand {
+
 	private ICommandResultFactory resultFactory;
 	private IPluginInfo pluginInfo;
 	private IPluginDbService pluginDbService;
@@ -44,13 +45,82 @@ public class GetExecutionInfoCommand implements ICommand, ITaskAwareCommand {
 
 	@Override
 	public ICommandResult execute(ICommandContext context) {
-
 		return resultFactory.create(CommandResultStatus.OK, new ArrayList<String>(), this);
 	}
 
 	@Override
 	public ICommandResult validate(ICommandContext context) {
-		return resultFactory.create(CommandResultStatus.OK, null, this, null);
+		return resultFactory.create(CommandResultStatus.OK, null, this);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public void onTaskUpdate(ICommandExecutionResult result) {
+
+		ICommandExecutionResult res = getCommandDao().findExecutionResult(result.getId());
+		byte[] data = null;
+		if (res != null)
+			data = res.getResponseData();
+		Map<String, Object> responseData;
+		try {
+			responseData = new ObjectMapper().readValue(data, 0, data.length,
+					new TypeReference<HashMap<String, Object>>() {
+					});
+			if (responseData != null && !responseData.isEmpty() && responseData.containsKey("commandExecutionInfoList")
+					&& responseData.containsKey("versionList")) {
+				Object object = responseData.get("commandExecutionInfoList");
+				Object versionObject = responseData.get("versionList");
+				ArrayList<Object> list = (ArrayList<Object>) object;
+				ArrayList<Object> versionInfoList = (ArrayList<Object>) versionObject;
+				for (Object oldMap : versionInfoList) {
+					Map<String, String> map = (Map) oldMap;
+					CommandPackageVersion verInfo = new CommandPackageVersion();
+					verInfo.setAgentId(result.getAgentId());
+					verInfo.setTaskId(result.getCommandExecution().getCommand().getTask().getId());
+					verInfo.setCreateDate(new Date());
+					verInfo.setCommand(map.get("c").toString());
+					verInfo.setPackageName(map.get("p").toString());
+					verInfo.setPackageVersion(map.get("v").toString());
+
+					pluginDbService.save(verInfo);
+				}
+
+				for (Object oldMap : list) {
+					Map<String, String> map = (Map) oldMap;
+					CommandExecutionStatistics item = new CommandExecutionStatistics();
+					item.setCommand(map.get("c").toString());
+					item.setUser(map.get("u").toString());
+					Float processTime = Float.parseFloat(map.get("p").toString());
+					item.setProcessTime(processTime);
+					String currentYearString = Integer.toString(Calendar.getInstance().get(Calendar.YEAR));
+					DateFormat formatter = new SimpleDateFormat("E MMM dd HH:mm:ss yyyy");
+					item.setProcessStartDate(
+							(Date) formatter.parse(map.get("s").toString() + ":00 " + currentYearString));
+					item.setAgentId(result.getAgentId());
+					item.setTaskId(result.getCommandExecution().getCommand().getTask().getId());
+					item.setIsActive("1");
+					item.setCreateDate(new Date());
+					item.setCommandExecutionId(result.getCommandExecution().getId());
+
+					Query query = entityManager.createQuery(
+							"UPDATE CommandExecutionStatistics ces SET ces.isActive ='0' WHERE ces.agentId = :agentId AND ces.command = :command AND ces.user = :user AND ces.taskId <> :taskId");
+					query.setParameter("agentId", item.getAgentId());
+					query.setParameter("taskId", item.getTaskId());
+					query.setParameter("command", item.getCommand());
+					query.setParameter("user", item.getUser());
+					query.executeUpdate();
+					pluginDbService.save(item);
+				}
+			}
+		} catch (JsonParseException e) {
+			e.printStackTrace();
+		} catch (JsonMappingException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		} catch (ParseException e) {
+			e.printStackTrace();
+		}
 	}
 
 	@Override
@@ -103,88 +173,6 @@ public class GetExecutionInfoCommand implements ICommand, ITaskAwareCommand {
 
 	public void setTaskDao(ITaskDao taskDao) {
 		this.taskDao = taskDao;
-	}
-
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	@Override
-	public void onTaskUpdate(ICommandExecutionResult result) {
-		if (result != null && result.getCommandExecution() != null && result.getCommandExecution().getCommand() != null
-				&& result.getCommandExecution().getCommand().getTask() != null
-				&& result.getCommandExecution().getCommand().getTask().getCommandClsId() != null
-				&& result.getCommandExecution().getCommand().getTask().getPlugin() != null
-				&& result.getCommandExecution().getCommand().getTask().getPlugin().getName() != null
-				&& result.getCommandExecution().getCommand().getTask().getCommandClsId().toUpperCase()
-						.equals("GET_EXECUTION_INFO")
-				&& "PACKAGE-MANAGER".equals(
-						result.getCommandExecution().getCommand().getTask().getPlugin().getName().toUpperCase())) {
-
-			ICommandExecutionResult res = getCommandDao().findExecutionResult(result.getId());
-			byte[] data  = null;
-			if(res != null)
-				data = res.getResponseData();
-			Map<String, Object> responseData;
-			try {
-				responseData = new ObjectMapper().readValue(data, 0, data.length,
-						new TypeReference<HashMap<String, Object>>() {
-						});
-				if (responseData != null && !responseData.isEmpty()
-						&& responseData.containsKey("commandExecutionInfoList")
-						&& responseData.containsKey("versionList")) {
-					Object object = responseData.get("commandExecutionInfoList");
-					Object versionObject = responseData.get("versionList");
-					ArrayList<Object> list = (ArrayList<Object>) object;
-					ArrayList<Object> versionInfoList = (ArrayList<Object>) versionObject;
-					for (Object oldMap : versionInfoList) {
-						Map<String, String> map = (Map) oldMap;
-						CommandPackageVersion verInfo = new CommandPackageVersion();
-						verInfo.setAgentId(result.getAgentId());
-						verInfo.setTaskId(result.getCommandExecution().getCommand().getTask().getId());
-						verInfo.setCreateDate(new Date());
-						verInfo.setCommand(map.get("c").toString());
-						verInfo.setPackageName(map.get("p").toString());
-						verInfo.setPackageVersion(map.get("v").toString());
-
-						pluginDbService.save(verInfo);
-					}
-
-					for (Object oldMap : list) {
-						Map<String, String> map = (Map) oldMap;
-						CommandExecutionStatistics item = new CommandExecutionStatistics();
-						item.setCommand(map.get("c").toString());
-						item.setUser(map.get("u").toString());
-						Float processTime = Float.parseFloat(map.get("p").toString());
-						item.setProcessTime(processTime);
-						String currentYearString = Integer.toString(Calendar.getInstance().get(Calendar.YEAR));
-						DateFormat formatter = new SimpleDateFormat("E MMM dd HH:mm:ss yyyy");
-						item.setProcessStartDate(
-								(Date) formatter.parse(map.get("s").toString() + ":00 " + currentYearString));
-						item.setAgentId(result.getAgentId());
-						item.setTaskId(result.getCommandExecution().getCommand().getTask().getId());
-						item.setIsActive("1");
-						item.setCreateDate(new Date());
-						item.setCommandExecutionId(result.getCommandExecution().getId());
-
-						Query query = entityManager.createQuery(
-								"UPDATE CommandExecutionStatistics ces SET ces.isActive ='0' WHERE ces.agentId = :agentId AND ces.command = :command AND ces.user = :user AND ces.taskId <> :taskId");
-						query.setParameter("agentId", item.getAgentId());
-						query.setParameter("taskId", item.getTaskId());
-						query.setParameter("command", item.getCommand());
-						query.setParameter("user", item.getUser());
-						query.executeUpdate();
-						pluginDbService.save(item);
-					}
-				}
-			} catch (JsonParseException e) {
-				e.printStackTrace();
-			} catch (JsonMappingException e) {
-				e.printStackTrace();
-			} catch (IOException e) {
-				e.printStackTrace();
-			} catch (ParseException e) {
-				e.printStackTrace();
-			}
-
-		}
 	}
 
 	public EntityManager getEntityManager() {

--- a/lider-package-manager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/lider-package-manager/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -90,11 +90,18 @@
 		<property name="pluginInfo" ref="pluginInfoImpl" />
 	</bean>
 	<!-- ICommand implementation is used to process a task execution -->
-	<service ref="CheckPackageCommand" interface="tr.org.liderahenk.lider.core.api.plugin.ICommand" />
+	<service ref="CheckPackageCommand">
+		<interfaces>
+			<value>tr.org.liderahenk.lider.core.api.plugin.ICommand</value>
+			<value>tr.org.liderahenk.lider.core.api.plugin.ITaskAwareCommand</value>
+		</interfaces>
+	</service>
 	<bean id="CheckPackageCommand"
 		class="tr.org.liderahenk.packagemanager.commands.CheckPackageCommand">
 		<property name="resultFactory" ref="resultFactory" />
 		<property name="pluginInfo" ref="pluginInfoImpl" />
+		<property name="agentDao" ref="agentDaoImpl" />
+		<property name="entityFactory" ref="entityFactory" />
 	</bean>
 	<!-- ICommand implementation is used to process a task execution -->
 	<service ref="PackagesCommand" interface="tr.org.liderahenk.lider.core.api.plugin.ICommand" />
@@ -146,4 +153,6 @@
 		interface="tr.org.liderahenk.lider.core.api.persistence.dao.ITaskDao" />
 	<reference id="commandDaoImpl"
 		interface="tr.org.liderahenk.lider.core.api.persistence.dao.ICommandDao" />
+	<reference id="entityFactory"
+		interface="tr.org.liderahenk.lider.core.api.persistence.factories.IEntityFactory" />
 </blueprint>


### PR DESCRIPTION
Sample implementation to demonstrate that plugins can contribute to agent properties.

Added feature:

* After a package check whether it is installed or not, the package becomes also agent property. 
(That way we can search for agents with specified package names directly in the LDAP search editor)